### PR TITLE
Support empty responses

### DIFF
--- a/src/BaseClient.php
+++ b/src/BaseClient.php
@@ -117,6 +117,10 @@ abstract class BaseClient {
 
 	abstract function processElement(\SimpleXMLElement $element, $index);
 
+	protected function isSpecialEmptyResponse($fileContent) {
+		return false;
+	}
+
 	protected function downloadFile() {
 
 		if (!$this->sourceAddress) {
@@ -172,8 +176,16 @@ abstract class BaseClient {
 		$mainNodeName = $this->getNodeName();
 
 		if ($this->tempFile) {
+			if ($this->isSpecialEmptyResponse(file_get_contents($this->tempFile))) {
+				return;
+			}
+
 			$xmlReader->open($this->tempFile);
 		} else {
+			if ($this->isSpecialEmptyResponse($this->xml)) {
+				return;
+			}
+
 			$xmlReader->XML($this->xml);
 		}
 

--- a/src/EshopReviewsClient.php
+++ b/src/EshopReviewsClient.php
@@ -74,6 +74,9 @@ class EshopReviewsClient extends BaseClient {
 
 	}
 
+	protected function isSpecialEmptyResponse($fileContent) {
+		return preg_match('/^INFO: No reviews/u', $fileContent);
+	}
 
 
 

--- a/src/ProductReviewsClient.php
+++ b/src/ProductReviewsClient.php
@@ -99,6 +99,10 @@ class ProductReviewsClient extends BaseClient {
 
 	}
 
+	protected function isSpecialEmptyResponse($fileContent) {
+		return preg_match('/^INFO: No product reviews/u', $fileContent);
+	}
+
 	/**
 	 * @return callable|null
 	 */

--- a/tests/example-data/eshop-reviews-empty.txt
+++ b/tests/example-data/eshop-reviews-empty.txt
@@ -1,0 +1,1 @@
+INFO: No reviews

--- a/tests/example-data/product-reviews-empty.txt
+++ b/tests/example-data/product-reviews-empty.txt
@@ -1,0 +1,1 @@
+INFO: No product reviews

--- a/tests/src/EshopReviewsClient.phpt
+++ b/tests/src/EshopReviewsClient.phpt
@@ -109,6 +109,22 @@ class EshopReviewsClientTest extends \Tester\TestCase {
 
 	}
 
+	function testParseNoReviews() {
+		$client = new EshopReviewsClient();
+
+		$client->useFile(__DIR__ . "/../example-data/eshop-reviews-empty.txt");
+
+		$reviews = array();
+
+		$client->setCallback(function(EshopReview $review) use (&$reviews) {
+			$reviews[] = $review;
+		});
+
+		$client->run();
+
+		Assert::same(0, count($reviews));
+	}
+
 	function testNullValues() {
 		$client = new EshopReviewsClient();
 

--- a/tests/src/ProductReviewsClient.phpt
+++ b/tests/src/ProductReviewsClient.phpt
@@ -120,6 +120,21 @@ class ProductReviewsClientTest extends \Tester\TestCase {
 
 	}
 
+	function testParseNoReviews() {
+		$client = new ProductReviewsClient();
+
+		$client->useFile(__DIR__ . "/../example-data/product-reviews-empty.txt");
+
+		$reviews = array();
+
+		$client->setCallback(function(ProductReview $review) use (&$reviews) {
+			$reviews[] = $review;
+		});
+
+		$client->run();
+
+		Assert::same(0, count($reviews));
+	}
 
 	function testSummaries() {
 


### PR DESCRIPTION
Heureka does not return valid XML in case that no reviews are present. Instead it returns plaintext response. Therefore we cannot let XMLReader parse such response otherwise we would end-up with an exception.
