### PR TITLE
composer.json: do not depend on "nette/tester" with "dev" stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": ">=5.3.1"
     },
     "require-dev": {
-        "nette/tester": "dev-master",
+        "nette/tester": "^1.4",
         "ondrakoupil/tools": "~0.0.6",
         "ondrakoupil/testing-utils": "~0.0.7"
     }


### PR DESCRIPTION
The package cannot depend on "dev" stability of "nette/tester" because dependency "ondrakoupil/testing-utils" requires "stable" version of "nette/tester".

I chose version ^1.4 because it is the minimal version that is required by the dependencies.
